### PR TITLE
Update dependencies: Akka 2.5 & Akka-persistence-inmemory 2.5 and etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](http://img.shields.io/:license-Apache%202-red.svg)](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 __akka-persistence-query-writer__ consists of an akka-streams `Flow` and `Sink` that makes it possible to write
-`EventEnvelope` , `Seq[EventEnvelope]`, `EventEnvelope2` or `Seq[EventEnvelope2]` to __any__ akka-persistence jounal.
+`EventEnvelope` , `Seq[EventEnvelope]` to __any__ akka-persistence jounal.
 It does this by sending messages directly to the [journal plugin itself](http://doc.akka.io/api/akka/2.4/#akka.persistence.journal.japi.AsyncWriteJournal).
 
 ## Installation
@@ -15,7 +15,7 @@ Add the following to your `build.sbt`:
 // the library is available in Bintray's JCenter
 resolvers += Resolver.jcenterRepo
 
-libraryDependencies += "com.github.dnvriend" %% "akka-persistence-journal-writer" % "0.0.2"
+libraryDependencies += "com.github.dnvriend" %% "akka-persistence-journal-writer" % "0.0.4"
 ```
 
 ## Contribution policy
@@ -26,12 +26,11 @@ Contributions via GitHub pull requests are gladly accepted from their original a
 This code is open source software licensed under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
 
 ## Basic Use Case
-The `akka-persistence-journal-writer` lets you write events to any journal. It accepts only two types of messages:
+The `akka-persistence-journal-writer` lets you write events to any journal. It accepts:
 
 - [akka.persistence.query.EventEnvelope](http://doc.akka.io/api/akka/2.4/#akka.persistence.query.EventEnvelope)
-- [akka.persistence.query.EventEnvelope2](http://doc.akka.io/api/akka/2.4/#akka.persistence.query.EventEnvelope2)
 
-Of course, you can send `immutable.Seq[EventEnvelope]` or `immutable.Seq[EventEnvelope2]` of those too for bulk loading.
+Of course, you can send `immutable.Seq[EventEnvelope]` of those too for bulk loading.
 
 The basic use case would be loading one event store into another. In this example we will be loading events from
 the inmemory-journal, using akka-persistence-query and loading the events into the level-db journal:

--- a/build.sbt
+++ b/build.sbt
@@ -1,29 +1,38 @@
-name := "akka-persistence-journal-writer"
+import sbt._
+import sbt.Keys._
 
-version := "0.0.2"
+name := "akka-persistence-journal-writer"
 
 organization := "com.github.dnvriend"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.6"
 
-crossScalaVersions := Seq("2.11.8", "2.12.0")
+crossScalaVersions := Seq("2.11.8", "2.12.6")
 
 resolvers += Resolver.jcenterRepo
+externalResolvers ++= Seq(
+  "dnvriend" at "https://dl.bintray.com/dnvriend/maven"
+)
 
 libraryDependencies ++= {
-  val akkaVersion = "2.4.12"
+  val akkaVersion = "2.5.15"
+  val akkaPersistenceInMemoryVersion = "2.5.1.2"
+  val commonIoVersion = "2.6"
+  val leveldbVersion = "0.10"
+  val leveldbJniVersion = "1.8"
+  val scalaTestVersion = "3.0.5"
   Seq(
     "com.typesafe.akka" %% "akka-actor" % akkaVersion,
     "com.typesafe.akka" %% "akka-persistence" % akkaVersion,
-    "com.typesafe.akka" %% "akka-persistence-query-experimental" % akkaVersion,
+    "com.typesafe.akka" %% "akka-persistence-query" % akkaVersion,
     "com.typesafe.akka" %% "akka-stream" % akkaVersion,
     "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % Test,
     "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
-    "com.github.dnvriend" %% "akka-persistence-inmemory" % "1.3.14" % Test,
-    "commons-io" % "commons-io" % "2.5" % Test,
-    "org.iq80.leveldb" % "leveldb" % "0.7" % Test,
-    "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8" % Test,
-    "org.scalatest" %% "scalatest" % "3.0.0" % Test
+    "com.github.dnvriend" %% "akka-persistence-inmemory" % akkaPersistenceInMemoryVersion % Test,
+    "commons-io" % "commons-io" % commonIoVersion % Test,
+    "org.iq80.leveldb" % "leveldb" % leveldbVersion % Test,
+    "org.fusesource.leveldbjni" % "leveldbjni-all" % leveldbJniVersion % Test,
+    "org.scalatest" %% "scalatest" % scalaTestVersion % Test
   )
 }
 
@@ -42,14 +51,11 @@ import scalariform.formatter.preferences._
 SbtScalariform.autoImport.scalariformPreferences := SbtScalariform.autoImport.scalariformPreferences.value
   .setPreference(AlignSingleLineCaseStatements, true)
   .setPreference(AlignSingleLineCaseStatements.MaxArrowIndent, 100)
-  .setPreference(DoubleIndentClassDeclaration, true)
+  .setPreference(DoubleIndentConstructorArguments, true)
 
 // enable updating file headers //
-import de.heikoseeberger.sbtheader.license.Apache2_0
 
-headers := Map(
-  "scala" -> Apache2_0("2016", "Dennis Vriend"),
-  "conf" -> Apache2_0("2016", "Dennis Vriend", "#")
-)
+import de.heikoseeberger.sbtheader._
+headerLicense := Some(HeaderLicense.ALv2("2016", "Dennis Vriend"))
 
 enablePlugins(AutomateHeaderPlugin)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.1.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,10 +3,12 @@ resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositori
 resolvers += "bintray-sbt-plugin-releases" at "http://dl.bintray.com/content/sbt/sbt-plugin-releases"
 
 // to deploy to bintray
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
 
 // to format scala source code
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 
 // enable updating file headers eg. for copyright
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.5.1")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0")
+
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.4")

--- a/src/main/scala/akka/persistence/journal/writer/package.scala
+++ b/src/main/scala/akka/persistence/journal/writer/package.scala
@@ -18,14 +18,14 @@ package akka.persistence.journal
 
 import akka.actor.{ ActorContext, ActorRef }
 import akka.persistence.JournalProtocol.WriteMessages
-import akka.persistence.query.{ EventEnvelope, EventEnvelope2 }
+import akka.persistence.query.EventEnvelope
 import akka.persistence.{ AtomicWrite, PersistentRepr }
 
 import scala.collection.immutable.{ Map, Seq }
 import scala.reflect.ClassTag
 
 package object writer {
-  val unsupported: Throwable = new IllegalArgumentException("JournalWriter only accepts EventEnvelope, immutable.Seq[EventEnvelope], EventEnvelope2 and immutable.Seq[EventEnvelope2]")
+  val unsupported: Throwable = new IllegalArgumentException("JournalWriter only accepts EventEnvelope, immutable.Seq[EventEnvelope]")
 
   def replyWithFailure(replyTo: ActorRef, cause: Throwable = unsupported)(implicit ctx: ActorContext, self: ActorRef): Unit = {
     replyTo ! akka.actor.Status.Failure(cause)
@@ -47,8 +47,7 @@ package object writer {
     PersistentRepr(
       payload = env.event,
       sequenceNr = env.sequenceNr,
-      persistenceId = env.persistenceId
-    )
+      persistenceId = env.persistenceId)
 
   def listOfEnvelopeToRepr(xs: Seq[EventEnvelope]): Seq[PersistentRepr] =
     xs.map(toPersistentRepr)
@@ -63,9 +62,6 @@ package object writer {
         .mapValues(listOfReprToAtomicWrite)
     Seq(groupedByPid.values.toList: _*)
   }
-
-  def toEventEnvelope(x: EventEnvelope2): EventEnvelope =
-    EventEnvelope(0L, x.persistenceId, x.sequenceNr, x.event)
 
   def writeMessages(xs: Seq[EventEnvelope], writerJournalAdapter: ActorRef): WriteMessages =
     WriteMessages(toAtomicWrite(xs), writerJournalAdapter, 1)

--- a/src/test/scala/akka/persistence/journal/LevelDbCleanup.scala
+++ b/src/test/scala/akka/persistence/journal/LevelDbCleanup.scala
@@ -23,8 +23,7 @@ import org.scalatest.BeforeAndAfterAll
 
 trait LevelDbCleanup { _: TestSpec with BeforeAndAfterAll =>
   def storageLocations = List(
-    "akka.persistence.journal.leveldb.dir"
-  ).map(s => new File(system.settings.config.getString(s)))
+    "akka.persistence.journal.leveldb.dir").map(s => new File(system.settings.config.getString(s)))
 
   override protected def beforeAll(): Unit = {
     storageLocations.foreach(FileUtils.deleteDirectory)

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version := "0.0.5-SNAPSHOT"


### PR DESCRIPTION
Update dependencies: Akka 2.5 & Akka-persistence-inmemory 2.5. Getting rid of EventEnvelope2.